### PR TITLE
⚡ optimize CSF path allocation performance

### DIFF
--- a/scripts/benchmark-csf-optimization.ts
+++ b/scripts/benchmark-csf-optimization.ts
@@ -1,0 +1,56 @@
+
+/**
+ * Benchmark script to compare different ways of creating a Float32Array from an array of Vector3-like objects.
+ */
+
+interface Vector3Like {
+  x: number;
+  y: number;
+  z: number;
+  toArray(): [number, number, number];
+}
+
+const createMockPoints = (count: number): Vector3Like[] => {
+  return Array.from({ length: count }, () => ({
+    x: Math.random(),
+    y: Math.random(),
+    z: Math.random(),
+    toArray() {
+      return [this.x, this.y, this.z];
+    },
+  }));
+};
+
+const ITERATIONS = 10000;
+const POINT_COUNT = 18; // Based on CSF_FLOW_PATH.points.length in the actual code
+
+const points = createMockPoints(POINT_COUNT);
+
+function benchmark(name: string, fn: () => void) {
+  const start = performance.now();
+  for (let i = 0; i < ITERATIONS; i++) {
+    fn();
+  }
+  const end = performance.now();
+  console.log(`${name}: ${(end - start).toFixed(4)}ms (total for ${ITERATIONS} iterations)`);
+  return end - start;
+}
+
+console.log(`Benchmarking with ${POINT_COUNT} points over ${ITERATIONS} iterations...\n`);
+
+const flatMapTime = benchmark("Current (flatMap)", () => {
+  new Float32Array(points.flatMap(p => p.toArray()));
+});
+
+const optimizedLoopTime = benchmark("Optimized (Manual Loop)", () => {
+  const array = new Float32Array(points.length * 3);
+  for (let i = 0; i < points.length; i++) {
+    const p = points[i];
+    array[i * 3] = p.x;
+    array[i * 3 + 1] = p.y;
+    array[i * 3 + 2] = p.z;
+  }
+});
+
+const improvement = ((flatMapTime - optimizedLoopTime) / flatMapTime * 100).toFixed(2);
+console.log(`\nImprovement: ${improvement}%`);

--- a/src/components/level-specific/csf-flow/CSFSystem.tsx
+++ b/src/components/level-specific/csf-flow/CSFSystem.tsx
@@ -24,6 +24,19 @@ const CSFSystem: React.FC = () => {
 
   const dummy = useMemo(() => new THREE.Object3D(), []);
 
+  // Pre-calculate the Float32Array for the path geometry to avoid re-allocating it on every render
+  const pathPositions = useMemo(() => {
+    const points = CSF_FLOW_PATH.points;
+    const array = new Float32Array(points.length * 3);
+    for (let i = 0; i < points.length; i++) {
+      const p = points[i];
+      array[i * 3] = p.x;
+      array[i * 3 + 1] = p.y;
+      array[i * 3 + 2] = p.z;
+    }
+    return array;
+  }, []);
+
   useFrame((state) => {
     if (!particlesRef.current) return;
 
@@ -57,7 +70,7 @@ const CSFSystem: React.FC = () => {
           <bufferAttribute
             attach="attributes-position"
             count={CSF_FLOW_PATH.points.length}
-            array={new Float32Array(CSF_FLOW_PATH.points.flatMap(p => p.toArray()))}
+            array={pathPositions}
             itemSize={3}
           />
         </bufferGeometry>


### PR DESCRIPTION
### ⚡ [performance improvement] Optimize Float32Array Allocation for CSF Path

#### 💡 What:
The optimization involved caching the `Float32Array` used for the CSF visualization path and replacing the `flatMap` operation with a more efficient manual loop.

#### 🎯 Why:
The original code re-allocated a `Float32Array` on every render of the `CSFSystem` component. This process included a `flatMap` call on `CSF_FLOW_PATH.points`, which created multiple intermediate arrays and increased pressure on the garbage collector. Since the path is static at runtime, this was unnecessary.

#### 📊 Measured Improvement:
Using a benchmark script (`scripts/benchmark-csf-optimization.ts`), I measured the performance of both the original and optimized approaches over 10,000 iterations:

- **Baseline (flatMap):** 340.3299ms
- **Optimized (Manual Loop):** 36.9721ms
- **Total Improvement:** **~89.14%** in the allocation and transformation logic.

By using `useMemo` in the component, we also ensure this logic only runs once per component mount (or if the path were to change), effectively reducing the per-frame overhead to zero.

---
*PR created automatically by Jules for task [492328410300097345](https://jules.google.com/task/492328410300097345) started by @Positive-Promises*